### PR TITLE
fix: allow public auth host in production

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,9 +7,9 @@
 APP_ENV=development
 DJANGO_DEBUG=true
 DJANGO_SECRET_KEY=replace-with-a-local-dev-secret
-DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost
-DJANGO_CSRF_TRUSTED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
-DJANGO_CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
+DJANGO_ALLOWED_HOSTS=47.85.103.76,127.0.0.1,localhost
+DJANGO_CSRF_TRUSTED_ORIGINS=http://47.85.103.76:5173,http://127.0.0.1:5173,http://localhost:5173
+DJANGO_CORS_ALLOWED_ORIGINS=http://47.85.103.76:5173,http://127.0.0.1:5173,http://localhost:5173
 
 # Optional. If omitted, settings.py falls back to backend/media.
 MEDIA_URL=/media/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,9 +20,9 @@ services:
       APP_ENV: production
       DJANGO_DEBUG: ${DJANGO_DEBUG:-false}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-change-me-in-.env.backend}
-      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-127.0.0.1,localhost}
-      DJANGO_CORS_ALLOWED_ORIGINS: ${DJANGO_CORS_ALLOWED_ORIGINS:-http://127.0.0.1,http://localhost}
-      DJANGO_CSRF_TRUSTED_ORIGINS: ${DJANGO_CSRF_TRUSTED_ORIGINS:-http://127.0.0.1,http://localhost}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-47.85.103.76,127.0.0.1,localhost}
+      DJANGO_CORS_ALLOWED_ORIGINS: ${DJANGO_CORS_ALLOWED_ORIGINS:-http://47.85.103.76:5173,http://127.0.0.1:5173,http://localhost:5173}
+      DJANGO_CSRF_TRUSTED_ORIGINS: ${DJANGO_CSRF_TRUSTED_ORIGINS:-http://47.85.103.76:5173,http://127.0.0.1:5173,http://localhost:5173}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-change-me-jwt-in-.env.backend}
       DB_ENGINE: ${DB_ENGINE:-mysql}
       DB_NAME: ${DB_NAME:-finmodpro}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,6 +38,14 @@ Recommended split:
 
 These files are sourced by `scripts/deploy.sh` before `docker compose -f docker-compose.prod.yml up -d --build`.
 
+For the current public deployment entrypoint at `http://47.85.103.76:5173`, `.env.backend` must allow that host and origin:
+
+- `DJANGO_ALLOWED_HOSTS=47.85.103.76,127.0.0.1,localhost`
+- `DJANGO_CSRF_TRUSTED_ORIGINS=http://47.85.103.76:5173,http://127.0.0.1:5173,http://localhost:5173`
+- `DJANGO_CORS_ALLOWED_ORIGINS=http://47.85.103.76:5173,http://127.0.0.1:5173,http://localhost:5173`
+
+If these values only contain localhost, Django will reject proxied requests with an HTML `400 Bad Request` before `login/register` reaches the auth controller.
+
 ## First Deploy Preconditions
 
 Before the first GitHub Actions deploy, confirm the target host has:


### PR DESCRIPTION
Fixes fliycode/finmodpro#3

## Summary
- include the public deployment host `47.85.103.76` in the production Django host/origin defaults
- align `DJANGO_ALLOWED_HOSTS`, `DJANGO_CORS_ALLOWED_ORIGINS`, and `DJANGO_CSRF_TRUSTED_ORIGINS` with the actual public entrypoint `http://47.85.103.76:5173`
- document why missing these values causes Django to return an HTML 400 before auth views run

## Verification
- live probe before deployment: `POST http://47.85.103.76:5173/api/auth/login` -> `HTTP/1.1 400 Bad Request`, `Content-Type: text/html; charset=utf-8`
- live probe before deployment: `POST http://47.85.103.76:5173/api/auth/register` -> `HTTP/1.1 400 Bad Request`, `Content-Type: text/html; charset=utf-8`
- local Django reproduction with `DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost` and `Host: 47.85.103.76:5173` -> HTML 400 matching production
- local Django verification with `DJANGO_ALLOWED_HOSTS=47.85.103.76,127.0.0.1,localhost` and same host header:
  - `POST /api/auth/login` -> `401 application/json` for bad credentials
  - `POST /api/auth/register` -> `201 application/json` for valid payload

## Notes
- production still needs this branch deployed; the live endpoint is not fixed yet at PR creation time
